### PR TITLE
modify isJsonrpc

### DIFF
--- a/src/entities/Jsonrpc.ts
+++ b/src/entities/Jsonrpc.ts
@@ -7,5 +7,5 @@ export interface JsonrpcRequestBody {
   jsonrpc: JsonrpcVersion;
   id: JsonrpcId;
   method: JsonrpcMethod;
-  params: JsonrpcParams;
+  params?: JsonrpcParams | null;
 }

--- a/src/services/__tests__/jsonrpcCheck.service.spec.ts
+++ b/src/services/__tests__/jsonrpcCheck.service.spec.ts
@@ -60,6 +60,36 @@ describe('isJsonrcp', () => {
     };
     expect(jsonrpcCheckService.isJsonrcp(body)).toBe(false);
   });
+
+  it('body.params is empty Array', () => {
+    const body = {
+      jsonrpc: '2.0',
+      method: 'eth_sendRawTransaction',
+      params: [],
+      id: 1,
+    };
+    expect(jsonrpcCheckService.isJsonrcp(body)).toBe(true);
+  });
+
+  it('body.params is undefined', () => {
+    const body = {
+      jsonrpc: '2.0',
+      method: 'eth_sendRawTransaction',
+      params: undefined,
+      id: 1,
+    };
+    expect(jsonrpcCheckService.isJsonrcp(body)).toBe(true);
+  });
+
+  it('body.params is null', () => {
+    const body = {
+      jsonrpc: '2.0',
+      method: 'eth_sendRawTransaction',
+      params: null,
+      id: 1,
+    };
+    expect(jsonrpcCheckService.isJsonrcp(body)).toBe(true);
+  });
 });
 
 describe('isJsonrcpArray', () => {

--- a/src/services/__tests__/proxy.service.spec.ts
+++ b/src/services/__tests__/proxy.service.spec.ts
@@ -395,6 +395,88 @@ describe('ProxyService', () => {
       expect(jest.spyOn(txService, 'checkAllowedGas')).not.toHaveBeenCalled();
     });
 
+    it('tx method is eth_sendRawTransaction and body.params is null', async () => {
+      const allowedMethods: RegExp[] = [/^.*$/];
+      const method = 'eth_sendRawTransaction';
+      const headers = { host: 'localhost' };
+      const body = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: method,
+        params: null,
+      };
+      const errMsg = 'rawTransaction is not found';
+      const errCode = -32602;
+      const status = 200;
+      const verseData = {
+        jsonrpc: body.jsonrpc,
+        id: body.id,
+        error: {
+          code: errCode,
+          message: errMsg,
+        },
+      };
+      const postResponse = {
+        status: status,
+        data: verseData,
+      };
+
+      jest.spyOn(configService, 'get').mockReturnValue(allowedMethods);
+
+      const proxyService = new ProxyService(
+        configService,
+        verseService,
+        txService,
+      );
+
+      const result = await proxyService.requestVerse(headers, body);
+      expect(result).toEqual(postResponse);
+      expect(jest.spyOn(txService, 'parseRawTx')).not.toHaveBeenCalled();
+      expect(jest.spyOn(txService, 'checkAllowedTx')).not.toHaveBeenCalled();
+      expect(jest.spyOn(txService, 'checkAllowedGas')).not.toHaveBeenCalled();
+    });
+
+    it('tx method is eth_sendRawTransaction and body.params is []', async () => {
+      const allowedMethods: RegExp[] = [/^.*$/];
+      const method = 'eth_sendRawTransaction';
+      const headers = { host: 'localhost' };
+      const body = {
+        jsonrpc: '2.0',
+        id: 1,
+        method: method,
+        params: [],
+      };
+      const errMsg = 'rawTransaction is not found';
+      const errCode = -32602;
+      const status = 200;
+      const verseData = {
+        jsonrpc: body.jsonrpc,
+        id: body.id,
+        error: {
+          code: errCode,
+          message: errMsg,
+        },
+      };
+      const postResponse = {
+        status: status,
+        data: verseData,
+      };
+
+      jest.spyOn(configService, 'get').mockReturnValue(allowedMethods);
+
+      const proxyService = new ProxyService(
+        configService,
+        verseService,
+        txService,
+      );
+
+      const result = await proxyService.requestVerse(headers, body);
+      expect(result).toEqual(postResponse);
+      expect(jest.spyOn(txService, 'parseRawTx')).not.toHaveBeenCalled();
+      expect(jest.spyOn(txService, 'checkAllowedTx')).not.toHaveBeenCalled();
+      expect(jest.spyOn(txService, 'checkAllowedGas')).not.toHaveBeenCalled();
+    });
+
     it('tx method is eth_sendRawTransaction and checkAllowedTx is failed', async () => {
       const rawTx =
         '0x02f86f05038459682f008459682f12825208948626f6940e2eb28930efb4cef49b2d1f2c9c119985e8d4a5100080c080a079448db43a092a4bf489fe93fa8a7c09ac25f3d8e5a799d401c8d105cccdd029a0743a0f064dc9cff4748b6d5e39dda262a89f0595570b41b0b576584d12348239';

--- a/src/services/jsonrpcCheck.service.ts
+++ b/src/services/jsonrpcCheck.service.ts
@@ -8,7 +8,14 @@ export class JsonrpcCheckService {
     if (typeof body.id !== 'string' && typeof body.id !== 'number')
       return false;
     if (typeof body.method !== 'string') return false;
-    if (!Array.isArray(body.params)) return false;
+    if (
+      !(
+        Array.isArray(body.params) ||
+        body.params === null ||
+        body.params === undefined
+      )
+    )
+      return false;
     return true;
   }
 

--- a/src/services/proxy.service.ts
+++ b/src/services/proxy.service.ts
@@ -53,7 +53,9 @@ export class ProxyService {
         return result;
       }
 
-      const rawTx = body.params[0];
+      const rawTx = body.params ? body.params[0] : undefined;
+      if (!rawTx) throw new JsonrpcError('rawTransaction is not found', -32602);
+
       const tx = this.txService.parseRawTx(rawTx);
       this.txService.checkAllowedTx(tx);
       await this.txService.checkAllowedGas(tx, body.jsonrpc, body.id);


### PR DESCRIPTION
# modification

## patern1
request
```json
{
    "jsonrpc": "2.0",
    "method": "eth_blockNumber",
    "params": null,
    "id": 1
}
```

response
```json
{
    "jsonrpc": "2.0",
    "method": "eth_blockNumber",
    "params": null,
    "id": 1
}
```

## patern2
request
```json
{
    "jsonrpc": "2.0",
    "method": "eth_blockNumber",
    "params": [],
    "id": 1
}
```

response
```json
{
    "jsonrpc": "2.0",
    "method": "eth_blockNumber",
    "params": null,
    "id": 1
}
```